### PR TITLE
Introduce optional ZFSBOOT_POOL_SIZE

### DIFF
--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1099,18 +1099,20 @@ zfs_create_boot()
 		           "$ZFSBOOT_BOOT_POOL_SIZE"
 		return $FAILURE
 	fi
-	if [ "$ZFSBOOT_POOL_SIZE" ] && ! f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize; then
-		f_dprintf "$funcname: Invalid pool size \`%s'" \
-			  "$ZFSBOOT_POOL_SIZE"
-		f_show_err "$msg_invalid_pool_size" \
-			   "$ZFSBOOT_POOL_SIZE"
+	if [ "$ZFSBOOT_POOL_SIZE" ]; then
+		if ! f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize; then
+			f_dprintf "$funcname: Invalid pool size \`%s'" \
+				  "$ZFSBOOT_POOL_SIZE"
+			f_show_err "$msg_invalid_pool_size" \
+				   "$ZFSBOOT_POOL_SIZE"
+		fi
+		f_dprintf "$funcname: ZFSBOOT_POOL_SIZE=[%s] poolsize=[%s]" \
+			  "$ZFSBOOT_POOL_SIZE" "$poolsize"
 	fi
 	f_dprintf "$funcname: ZFSBOOT_SWAP_SIZE=[%s] swapsize=[%s]" \
 	          "$ZFSBOOT_SWAP_SIZE" "$swapsize"
 	f_dprintf "$funcname: ZFSBOOT_BOOT_POOL_SIZE=[%s] bootsize=[%s]" \
 	          "$ZFSBOOT_BOOT_POOL_SIZE" "$bootsize"
-	f_dprintf "$funcname: ZFSBOOT_POOL_SIZE=[%s] poolsize=[%s]" \
-		  "$ZFSBOOT_POOL_SIZE" "$poolsize"
 
 	#
 	# Destroy the pool in-case this is our second time 'round (case of
@@ -1536,9 +1538,10 @@ while :; do
 
 		# Make sure each disk will be at least 50% ZFS
 		if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize &&
-		   f_expand_number "$ZFSBOOT_BOOT_POOL_SIZE" bootsize &&
-		   f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize
+		   f_expand_number "$ZFSBOOT_BOOT_POOL_SIZE" bootsize
 		then
+			[ "$ZFSBOOT_BOOT_POOL" ] && 
+				f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize
 			minsize=$swapsize teeny_disks=
 			[ "$ZFSBOOT_BOOT_POOL" ] &&
 				minsize=$(( $minsize + $bootsize ))

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -2,7 +2,6 @@
 #-
 # Copyright (c) 2013-2015 Allan Jude
 # Copyright (c) 2013-2015 Devin Teske
-# Copyright (c) 2015 John Ko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -2,6 +2,7 @@
 #-
 # Copyright (c) 2013-2015 Allan Jude
 # Copyright (c) 2013-2015 Devin Teske
+# Copyright (c) 2015 John Ko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -43,6 +44,11 @@ f_include $BSDCFG_SHARE/variable.subr
 # Default name of the boot-pool
 #
 : ${ZFSBOOT_POOL_NAME:=zroot}
+
+#
+# Default pool size
+#
+: ${ZFSBOOT_POOL_SIZE=}
 
 #
 # Default options to use when creating zroot pool
@@ -248,6 +254,7 @@ msg_install_help="Create ZFS boot pool with displayed options"
 msg_invalid_boot_pool_size="Invalid boot pool size \`%s'"
 msg_invalid_disk_argument="Invalid disk argument \`%s'"
 msg_invalid_index_argument="Invalid index argument \`%s'"
+msg_invalid_pool_size="Invalid pool size \`%s'"
 msg_invalid_swap_size="Invalid swap size \`%s'"
 msg_invalid_virtual_device_type="Invalid Virtual Device type \`%s'"
 msg_last_chance_are_you_sure="Last Chance! Are you sure you want to destroy\nthe current contents of the following disks:\n\n   %s"
@@ -305,6 +312,42 @@ msg_yes="YES"
 msg_zfs_configuration="ZFS Configuration"
 
 ############################################################ FUNCTIONS
+
+# glabel_of_diskpart
+#
+# Translate $disk$part to its glabel(8) or gptid, otherwise $disk$part
+#
+glabel_of_diskpart()
+{
+	local disk_and_part="$1"
+	if [ -n "${disk_and_part}" ]; then
+		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w )
+		if [ -n "${gptid}" ]; then
+			echo ${gptid}
+			return 0
+		fi
+	fi
+	echo ${disk_and_part}
+	return 1
+}
+
+# safe_glabel_of_diskpart
+#
+# Translate $disk$part to its glabel(8) or gptid and translate / to _ , otherwise $disk$part
+#
+safe_glabel_of_diskpart()
+{
+	local disk_and_part="$1"
+	if [ -n "${disk_and_part}" ]; then
+		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w | tr / _ )
+		if [ -n "${gptid}" ]; then
+			echo ${gptid}
+			return 0
+		fi
+	fi
+	echo ${disk_and_part}
+	return 1
+}
 
 # dialog_menu_main
 #
@@ -847,10 +890,10 @@ zfs_create_diskpart()
 		fi
 
 		#
-		# 2. Add small freebsd-boot partition labeled `boot#'
+		# 2. Add small freebsd-boot partition
 		#
-		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-		             "$align_small" gptboot$index freebsd-boot 512k $disk ||
+		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+		             "$align_small" $index freebsd-boot 512k $disk ||
 		             return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
@@ -867,43 +910,58 @@ zfs_create_diskpart()
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
 			f_eval_catch $funcname gpart \
-			             "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-			             "$align_big" boot$index freebsd-zfs \
+			             "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+			             "$align_big" $index freebsd-zfs \
 			             ${bootsize}b $disk ||
 			             return $FAILURE
 			# Pedantically nuke any old labels
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$bootpart
+			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
+			                /dev/$( glabel_of_diskpart $disk$bootpart )
 			if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 				# Pedantically detach targetpart for later
 				f_eval_catch -d $funcname geli \
 				                "$GELI_DETACH_F" \
 				                /dev/$disk$targetpart
+				f_eval_catch -d $funcname geli \
+				                "$GELI_DETACH_F" \
+				                /dev/$( glabel_of_diskpart $disk$targetpart )
 			fi
 		fi
 
 		#
-		# 3. Add freebsd-swap partition labeled `swap#'
+		# 3. Add freebsd-swap partition
 		#
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
-			             "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+			             "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
 			             "$align_big" swap$index freebsd-swap \
 			             ${swapsize}b $disk ||
 			             return $FAILURE
 			# Pedantically nuke any old labels on the swap
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$swappart
+			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
+			                /dev/$( glabel_of_diskpart $disk$swappart )
 		fi
 
 		#
-		# 4. Add freebsd-zfs partition labeled `zfs#' for zroot
+		# 4. Add freebsd-zfs partition for zroot
 		#
-		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
-		             "$align_big" zfs$index freebsd-zfs $disk ||
+		if [ "$ZFSBOOT_POOL_SIZE" ]; then
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+		             "$align_big" $index freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
 		             return $FAILURE
+		else
+		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
+		             "$align_big" $index freebsd-zfs $disk ||
+		             return $FAILURE
+		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart
+		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
+		                /dev/$( glabel_of_diskpart $disk$targetpart )
 		;;
 
 	MBR) f_dprintf "$funcname: Creating MBR layout..."
@@ -949,11 +1007,16 @@ zfs_create_diskpart()
 		# Pedantically nuke any old labels
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$bootpart
+		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
+		                /dev/$( glabel_of_diskpart $disk$bootpart )
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 			# Pedantically detach targetpart for later
 			f_eval_catch -d $funcname geli \
 			                "$GELI_DETACH_F" \
 					/dev/$disk$targetpart
+			f_eval_catch -d $funcname geli \
+			                "$GELI_DETACH_F" \
+					/dev/$( glabel_of_diskpart $disk$targetpart )
 		fi
 
 		#
@@ -972,10 +1035,17 @@ zfs_create_diskpart()
 		#
 		# 5. Add freebsd-zfs partition for zroot
 		#
+		if [ "$ZFSBOOT_POOL_SIZE" ]; then
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+		             "$align_small" $mbrindex freebsd-zfs $ZFSBOOT_POOL_SIZE ${disk}s1 || return $FAILURE
+		else
 		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
 		             "$align_small" $mbrindex freebsd-zfs ${disk}s1 || return $FAILURE
+		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart # Pedantic
+		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
+		                /dev/$( glabel_of_diskpart $disk$targetpart ) # Pedantic
 		f_eval_catch $funcname dd "$DD_WITH_OPTIONS" \
 		             /boot/zfsboot /dev/${disk}s1 count=1 ||
 		             return $FAILURE
@@ -1002,14 +1072,14 @@ zfs_create_diskpart()
 		isswapmirror=1
 	elif [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$disk${swappart}.eli none swap sw 0 0 \
+		             /dev/$( glabel_of_diskpart $disk${swappart} ).eli none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	elif [ ${swapsize:-0} -eq 0 ]; then
 		# If swap is 0 sized, don't add it to fstab
 	else
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$disk$swappart none swap sw 0 0 \
+		             /dev/$( glabel_of_diskpart $disk$swappart ) none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	fi
@@ -1068,7 +1138,7 @@ zfs_create_boot()
 	# Expand SI units in desired sizes
 	#
 	f_dprintf "$funcname: Expanding supplied size values..."
-	local swapsize bootsize
+	local swapsize bootsize poolsize
 	if ! f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize; then
 		f_dprintf "$funcname: Invalid swap size \`%s'" \
 		          "$ZFSBOOT_SWAP_SIZE"
@@ -1082,10 +1152,18 @@ zfs_create_boot()
 		           "$ZFSBOOT_BOOT_POOL_SIZE"
 		return $FAILURE
 	fi
+	if [ "$ZFSBOOT_POOL_SIZE" ] && ! f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize; then
+		f_dprintf "$funcname: Invalid pool size \`%s'" \
+			  "$ZFSBOOT_POOL_SIZE"
+		f_show_err "$msg_invalid_pool_size" \
+			   "$ZFSBOOT_POOL_SIZE"
+	fi
 	f_dprintf "$funcname: ZFSBOOT_SWAP_SIZE=[%s] swapsize=[%s]" \
 	          "$ZFSBOOT_SWAP_SIZE" "$swapsize"
 	f_dprintf "$funcname: ZFSBOOT_BOOT_POOL_SIZE=[%s] bootsize=[%s]" \
 	          "$ZFSBOOT_BOOT_POOL_SIZE" "$bootsize"
+	f_dprintf "$funcname: ZFSBOOT_POOL_SIZE=[%s] poolsize=[%s]" \
+		  "$ZFSBOOT_POOL_SIZE" "$poolsize"
 
 	#
 	# Destroy the pool in-case this is our second time 'round (case of
@@ -1114,9 +1192,9 @@ zfs_create_boot()
 		# Now $bootpart, $targetpart, and $swappart are set (suffix
 		# for $disk)
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
-			boot_vdevs="$boot_vdevs $disk$bootpart"
+			boot_vdevs="$boot_vdevs $( glabel_of_diskpart $disk$bootpart )"
 		fi
-		zroot_vdevs="$zroot_vdevs $disk$targetpart"
+		zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart )"
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 			zroot_vdevs="$zroot_vdevs.eli"
 		fi
@@ -1196,9 +1274,9 @@ zfs_create_boot()
 				2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_PASSWORD_INIT" \
-				"$bootpool/boot/$disk$targetpart.eli" \
+				"$bootpool/boot/$( safe_glabel_of_diskpart $disk$targetpart ).eli" \
 				AES-XTS "$bootpool/$zroot_key" \
-				$disk$targetpart
+				$( glabel_of_diskpart $disk$targetpart )
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1206,7 +1284,7 @@ zfs_create_boot()
 			fi
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_ATTACH" \
-				"$bootpool/$zroot_key" $disk$targetpart
+				"$bootpool/$zroot_key" $( glabel_of_diskpart $disk$targetpart )
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1226,7 +1304,7 @@ zfs_create_boot()
 	#
 	if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
 		for disk in $disks; do
-			swap_devs="$swap_devs $disk$swappart"
+			swap_devs="$swap_devs $( glabel_of_diskpart $disk$swappart )"
 		done
 		f_eval_catch $funcname gmirror "$SWAP_GMIRROR_LABEL" \
 			"$swap_devs" || return $FAILURE
@@ -1397,17 +1475,17 @@ zfs_create_boot()
 		$BSDINSTALL_TMPBOOT/loader.conf.geli || return $FAILURE
 	for disk in $disks; do
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
-			geli_%s_keyfile0_load "$disk$targetpart YES" \
+			geli_%s_keyfile0_load "$( safe_glabel_of_diskpart $disk$targetpart ) YES" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_type \
-			"$disk$targetpart $disk$targetpart:geli_keyfile0" \
+			"$( safe_glabel_of_diskpart $disk$targetpart ) $( glabel_of_diskpart $disk$targetpart ):geli_keyfile0" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_name \
-			"$disk$targetpart \"$ZFSBOOT_GELI_KEY_FILE\"" \
+			"$( safe_glabel_of_diskpart $disk$targetpart ) \"$ZFSBOOT_GELI_KEY_FILE\"" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 	done
@@ -1511,7 +1589,8 @@ while :; do
 
 		# Make sure each disk will be at least 50% ZFS
 		if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize &&
-		   f_expand_number "$ZFSBOOT_BOOT_POOL_SIZE" bootsize
+		   f_expand_number "$ZFSBOOT_BOOT_POOL_SIZE" bootsize &&
+		   f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize
 		then
 			minsize=$swapsize teeny_disks=
 			[ "$ZFSBOOT_BOOT_POOL" ] &&

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1540,9 +1540,11 @@ while :; do
 		if f_expand_number "$ZFSBOOT_SWAP_SIZE" swapsize &&
 		   f_expand_number "$ZFSBOOT_BOOT_POOL_SIZE" bootsize
 		then
-			[ "$ZFSBOOT_BOOT_POOL" ] && 
-				f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize
 			minsize=$swapsize teeny_disks=
+			if [ "$ZFSBOOT_POOL_SIZE" ]; then
+				f_expand_number "$ZFSBOOT_POOL_SIZE" poolsize
+				minsize=$(( $minsize + $poolsize ))
+			fi
 			[ "$ZFSBOOT_BOOT_POOL" ] &&
 				minsize=$(( $minsize + $bootsize ))
 			for disk in $ZFSBOOT_DISKS; do

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -857,8 +857,8 @@ zfs_create_diskpart()
 		# 2. Add small freebsd-boot partition labeled `boot#'
 		#
 		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-				"$align_small" gptboot$index freebsd-boot 512k $disk ||
-				return $FAILURE
+			     "$align_small" gptboot$index freebsd-boot 512k $disk ||
+			     return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
 		             return $FAILURE
@@ -874,10 +874,10 @@ zfs_create_diskpart()
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
 			f_eval_catch $funcname gpart \
-					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" boot$index freebsd-zfs \
-					${bootsize}b $disk ||
-					return $FAILURE
+				     "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+				     "$align_big" boot$index freebsd-zfs \
+				     ${bootsize}b $disk ||
+				     return $FAILURE
 			# Pedantically nuke any old labels
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$bootpart
@@ -894,10 +894,10 @@ zfs_create_diskpart()
 		#
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
-					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" swap$index freebsd-swap \
-					${swapsize}b $disk ||
-					return $FAILURE
+				     "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+				     "$align_big" swap$index freebsd-swap \
+				     ${swapsize}b $disk ||
+				     return $FAILURE
 			# Pedantically nuke any old labels on the swap
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$swappart

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1175,11 +1175,6 @@ zfs_create_boot()
 	fi
 	local n=0
 	for disk in $disks; do
-		if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
-			glabeldisktarget=$disk$targetpart
-		else
-			glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
-		fi
 		zfs_create_diskpart $disk $n || return $FAILURE
 		# Now $bootpart, $targetpart, and $swappart are set (suffix
 		# for $disk)

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1078,10 +1078,10 @@ zfs_create_diskpart()
 		#
 		if [ "$ZFSBOOT_POOL_SIZE" ]; then
 			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-		             "$align_small" $mbrindex freebsd-zfs $ZFSBOOT_POOL_SIZE ${disk}s1 || return $FAILURE
+					"$align_small" $mbrindex freebsd-zfs $ZFSBOOT_POOL_SIZE ${disk}s1 || return $FAILURE
 		else
-		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
-		             "$align_small" $mbrindex freebsd-zfs ${disk}s1 || return $FAILURE
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
+					"$align_small" $mbrindex freebsd-zfs ${disk}s1 || return $FAILURE
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart # Pedantic

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1058,14 +1058,14 @@ zfs_create_diskpart()
 		isswapmirror=1
 	elif [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$( glabel_of_diskpart $disk$swappart ).eli none swap sw 0 0 \
+		             /dev/$disk${swappart}.eli none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	elif [ ${swapsize:-0} -eq 0 ]; then
 		# If swap is 0 sized, don't add it to fstab
 	else
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$( glabel_of_diskpart $disk$swappart ) none swap sw 0 0 \
+		             /dev/$disk$swappart none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	fi
@@ -1179,11 +1179,15 @@ zfs_create_boot()
 		# Now $bootpart, $targetpart, and $swappart are set (suffix
 		# for $disk)
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
-			boot_vdevs="$boot_vdevs $( glabel_of_diskpart $disk$bootpart )"
+			boot_vdevs="$boot_vdevs $disk$bootpart"
 		fi
-		zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart )"
+		# If using GELI we need to convert $disk$targetpart to the glabel
+		# so that the keyfile in loader.conf(5) will use the correct one
+		# if ever the disk order is different
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
-			zroot_vdevs="$zroot_vdevs.eli"
+			zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart ).eli"
+		else
+			zroot_vdevs="$zroot_vdevs $disk$targetpart"
 		fi
 
 		n=$(( $n + 1 ))
@@ -1298,12 +1302,7 @@ zfs_create_boot()
 	#
 	if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
 		for disk in $disks; do
-			if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
-				glabeldisktarget=$disk$swappart
-			else
-				glabeldisktarget=$( glabel_of_diskpart $disk$swappart )
-			fi
-			swap_devs="$swap_devs $glabeldisktarget"
+			swap_devs="$swap_devs $disk$swappart"
 		done
 		f_eval_catch $funcname gmirror "$SWAP_GMIRROR_LABEL" \
 			"$swap_devs" || return $FAILURE

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -1058,14 +1058,14 @@ zfs_create_diskpart()
 		isswapmirror=1
 	elif [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$disk${swappart}.eli none swap sw 0 0 \
+		             /dev/$( glabel_of_diskpart $disk$swappart ).eli none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	elif [ ${swapsize:-0} -eq 0 ]; then
 		# If swap is 0 sized, don't add it to fstab
 	else
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$disk$swappart none swap sw 0 0 \
+		             /dev/$( glabel_of_diskpart $disk$swappart ) none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	fi
@@ -1091,7 +1091,7 @@ zfs_create_boot()
 	local isswapmirror
 	local bootpart targetpart swappart # Set by zfs_create_diskpart() below
 	local create_options
-	local glabeldisktarget
+	local glabeldisktarget safeglabeldisktarget
 
 	#
 	# Pedantic checks; should never be seen
@@ -1259,14 +1259,16 @@ zfs_create_boot()
 		for disk in $disks; do
 			if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
 				glabeldisktarget=$disk$targetpart
+				safeglabeldisktarget=$disk$targetpart
 			else
-				glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
+				glabeldisktarget=$( glabel_of_diskpart $disk$targetpart )
+				safeglabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
 			fi
 			f_dialog_info "$msg_geli_setup" \
 				2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_PASSWORD_INIT" \
-				"$bootpool/boot/$glabeldisktarget.eli" \
+				"$bootpool/boot/$safeglabeldisktarget.eli" \
 				AES-XTS "$bootpool/$zroot_key" \
 				$glabeldisktarget
 			then
@@ -1296,7 +1298,12 @@ zfs_create_boot()
 	#
 	if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
 		for disk in $disks; do
-			swap_devs="$swap_devs $disk$swappart"
+			if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
+				glabeldisktarget=$disk$swappart
+			else
+				glabeldisktarget=$( glabel_of_diskpart $disk$swappart )
+			fi
+			swap_devs="$swap_devs $glabeldisktarget"
 		done
 		f_eval_catch $funcname gmirror "$SWAP_GMIRROR_LABEL" \
 			"$swap_devs" || return $FAILURE
@@ -1471,22 +1478,24 @@ zfs_create_boot()
 	for disk in $disks; do
 		if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
 			glabeldisktarget=$disk$targetpart
+			safeglabeldisktarget=$disk$targetpart
 		else
-			glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
+			glabeldisktarget=$( glabel_of_diskpart $disk$targetpart )
+			safeglabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
 		fi
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
-			geli_%s_keyfile0_load "$glabeldisktarget YES" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
+			geli_%s_keyfile0_load "$safeglabeldisktarget YES" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_type \
-			"$glabeldisktarget $glabeldisktarget:geli_keyfile0" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
+			"$safeglabeldisktarget $glabeldisktarget:geli_keyfile0" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_name \
-			"$glabeldisktarget \"$ZFSBOOT_GELI_KEY_FILE\"" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
+			"$safeglabeldisktarget \"$ZFSBOOT_GELI_KEY_FILE\"" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
 			return $FAILURE
 	done
 

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -936,7 +936,7 @@ zfs_create_diskpart()
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
 			             "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-			             "$align_big" swap$index freebsd-swap \
+			             "$align_big" $index freebsd-swap \
 			             ${swapsize}b $disk ||
 			             return $FAILURE
 			# Pedantically nuke any old labels on the swap

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -41,6 +41,11 @@ f_include $BSDCFG_SHARE/variable.subr
 ############################################################ CONFIGURATION
 
 #
+# Use gptid or glabels
+#
+: ${ZFSBOOT_USE_GPTID=}
+
+#
 # Default name of the boot-pool
 #
 : ${ZFSBOOT_POOL_NAME:=zroot}
@@ -794,6 +799,8 @@ zfs_create_diskpart()
 {
 	local funcname=zfs_create_diskpart
 	local disk="$1" index="$2"
+	# Create a short-ish uuid to append to index because glabel max length is about 15
+	local uuid=$( uuidgen | md5 | cut -c1-6 )
 
 	# Check arguments
 	if [ ! "$disk" ]; then
@@ -890,11 +897,17 @@ zfs_create_diskpart()
 		fi
 
 		#
-		# 2. Add small freebsd-boot partition
+		# 2. Add small freebsd-boot partition labeled `gptboot#'
 		#
-		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-		             "$align_small" $index freebsd-boot 512k $disk ||
-		             return $FAILURE
+		if [ "$ZFSBOOT_USE_GPTID" ]; then
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+					"$align_small" $index freebsd-boot 512k $disk ||
+					return $FAILURE
+		else
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+					"$align_small" gptboot$index$uuid freebsd-boot 512k $disk ||
+					return $FAILURE
+		fi
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
 		             return $FAILURE
@@ -904,16 +917,24 @@ zfs_create_diskpart()
 		[ ${swapsize:-0} -gt 0 ] && targetpart=p3
 
 		#
-		# Prepare boot pool if enabled (e.g., for geli(8))
+		# Prepare boot pool if enabled (e.g., for geli(8)) labeled `boot#'
 		#
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
-			f_eval_catch $funcname gpart \
-			             "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-			             "$align_big" $index freebsd-zfs \
-			             ${bootsize}b $disk ||
-			             return $FAILURE
+			if [ "$ZFSBOOT_USE_GPTID" ]; then
+				f_eval_catch $funcname gpart \
+						"$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+						"$align_big" $index freebsd-zfs \
+						${bootsize}b $disk ||
+						return $FAILURE
+			else
+				f_eval_catch $funcname gpart \
+						"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+						"$align_big" boot$index$uuid freebsd-zfs \
+						${bootsize}b $disk ||
+						return $FAILURE
+			fi
 			# Pedantically nuke any old labels
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$bootpart
@@ -931,14 +952,22 @@ zfs_create_diskpart()
 		fi
 
 		#
-		# 3. Add freebsd-swap partition
+		# 3. Add freebsd-swap partition labeled `swap#'
 		#
 		if [ ${swapsize:-0} -gt 0 ]; then
-			f_eval_catch $funcname gpart \
-			             "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-			             "$align_big" $index freebsd-swap \
-			             ${swapsize}b $disk ||
-			             return $FAILURE
+			if [ "$ZFSBOOT_USE_GPTID" ]; then
+				f_eval_catch $funcname gpart \
+						"$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+						"$align_big" $index freebsd-swap \
+						${swapsize}b $disk ||
+						return $FAILURE
+			else
+				f_eval_catch $funcname gpart \
+						"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+						"$align_big" swap$index$uuid freebsd-swap \
+						${swapsize}b $disk ||
+						return $FAILURE
+			fi
 			# Pedantically nuke any old labels on the swap
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$swappart
@@ -947,16 +976,28 @@ zfs_create_diskpart()
 		fi
 
 		#
-		# 4. Add freebsd-zfs partition for zroot
+		# 4. Add freebsd-zfs partition labeled `zfs#' for zroot
 		#
 		if [ "$ZFSBOOT_POOL_SIZE" ]; then
-			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-		             "$align_big" $index freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
-		             return $FAILURE
+			if [ "$ZFSBOOT_USE_GPTID" ]; then
+				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
+						"$align_big" $index freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
+						return $FAILURE
+			else
+				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+						"$align_big" zfs$index$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
+						return $FAILURE
+			fi
 		else
-		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
-		             "$align_big" $index freebsd-zfs $disk ||
-		             return $FAILURE
+			if [ "$ZFSBOOT_USE_GPTID" ]; then
+				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
+						"$align_big" $index freebsd-zfs $disk ||
+						return $FAILURE
+			else
+				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
+						"$align_big" zfs$index$uuid freebsd-zfs $disk ||
+						return $FAILURE
+			fi
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -313,42 +313,6 @@ msg_zfs_configuration="ZFS Configuration"
 
 ############################################################ FUNCTIONS
 
-# glabel_of_diskpart
-#
-# Translate $disk$part to its glabel(8) or gptid, otherwise $disk$part
-#
-glabel_of_diskpart()
-{
-	local disk_and_part="$1"
-	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | awk '{print $1}' )
-		if [ -n "${gptid}" ]; then
-			echo ${gptid}
-			return 0
-		fi
-	fi
-	echo ${disk_and_part}
-	return 1
-}
-
-# safe_glabel_of_diskpart
-#
-# Translate $disk$part to its glabel(8) or gptid and translate / to _ , otherwise $disk$part
-#
-safe_glabel_of_diskpart()
-{
-	local disk_and_part="$1"
-	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | awk '{print $1}' | tr / _ )
-		if [ -n "${gptid}" ]; then
-			echo ${gptid}
-			return 0
-		fi
-	fi
-	echo ${disk_and_part}
-	return 1
-}
-
 # dialog_menu_main
 #
 # Display the dialog(1)-based application main menu.
@@ -794,8 +758,6 @@ zfs_create_diskpart()
 {
 	local funcname=zfs_create_diskpart
 	local disk="$1" index="$2"
-	# Create a short-ish uuid to append to index because glabel max length is about 15
-	local uuid=$( uuidgen | md5 | cut -c1-6 )
 
 	# Check arguments
 	if [ ! "$disk" ]; then
@@ -892,10 +854,10 @@ zfs_create_diskpart()
 		fi
 
 		#
-		# 2. Add small freebsd-boot partition labeled `gptboot#'
+		# 2. Add small freebsd-boot partition labeled `boot#'
 		#
 		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-				"$align_small" gptboot$uuid freebsd-boot 512k $disk ||
+				"$align_small" gptboot$index freebsd-boot 512k $disk ||
 				return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
@@ -906,14 +868,14 @@ zfs_create_diskpart()
 		[ ${swapsize:-0} -gt 0 ] && targetpart=p3
 
 		#
-		# Prepare boot pool if enabled (e.g., for geli(8)) labeled `boot#'
+		# Prepare boot pool if enabled (e.g., for geli(8))
 		#
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
 			f_eval_catch $funcname gpart \
 					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" boot$uuid freebsd-zfs \
+					"$align_big" boot$index freebsd-zfs \
 					${bootsize}b $disk ||
 					return $FAILURE
 			# Pedantically nuke any old labels
@@ -933,7 +895,7 @@ zfs_create_diskpart()
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
 					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" swap$uuid freebsd-swap \
+					"$align_big" swap$index freebsd-swap \
 					${swapsize}b $disk ||
 					return $FAILURE
 			# Pedantically nuke any old labels on the swap
@@ -946,11 +908,11 @@ zfs_create_diskpart()
 		#
 		if [ "$ZFSBOOT_POOL_SIZE" ]; then
 			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" zfs$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
+					"$align_big" zfs$index freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
 					return $FAILURE
 		else
 			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
-					"$align_big" zfs$uuid freebsd-zfs $disk ||
+					"$align_big" zfs$index freebsd-zfs $disk ||
 					return $FAILURE
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
@@ -1091,7 +1053,6 @@ zfs_create_boot()
 	local isswapmirror
 	local bootpart targetpart swappart # Set by zfs_create_diskpart() below
 	local create_options
-	local glabeldisktarget safeglabeldisktarget
 
 	#
 	# Pedantic checks; should never be seen
@@ -1181,13 +1142,9 @@ zfs_create_boot()
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
 			boot_vdevs="$boot_vdevs $disk$bootpart"
 		fi
-		# If using GELI we need to convert $disk$targetpart to the glabel
-		# so that the keyfile in loader.conf(5) will use the correct one
-		# if ever the disk order is different
+		zroot_vdevs="$zroot_vdevs $disk$targetpart"
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
-			zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart ).eli"
-		else
-			zroot_vdevs="$zroot_vdevs $disk$targetpart"
+			zroot_vdevs="$zroot_vdevs.eli"
 		fi
 
 		n=$(( $n + 1 ))
@@ -1261,20 +1218,13 @@ zfs_create_boot()
 
 		# Initialize geli(8) on each of the target partitions
 		for disk in $disks; do
-			if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
-				glabeldisktarget=$disk$targetpart
-				safeglabeldisktarget=$disk$targetpart
-			else
-				glabeldisktarget=$( glabel_of_diskpart $disk$targetpart )
-				safeglabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
-			fi
 			f_dialog_info "$msg_geli_setup" \
 				2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_PASSWORD_INIT" \
-				"$bootpool/boot/$safeglabeldisktarget.eli" \
+				"$bootpool/boot/$disk$targetpart.eli" \
 				AES-XTS "$bootpool/$zroot_key" \
-				$glabeldisktarget
+				$disk$targetpart
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1282,7 +1232,7 @@ zfs_create_boot()
 			fi
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_ATTACH" \
-				"$bootpool/$zroot_key" $glabeldisktarget
+				"$bootpool/$zroot_key" $disk$targetpart
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1424,9 +1374,6 @@ zfs_create_boot()
 	             'kern.geom.label.disk_ident.enable=\"0\"' \
 	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
 	f_eval_catch $funcname echo "$ECHO_APPEND" \
-	             'kern.geom.label.gpt.enable=\"1\"' \
-	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
-	f_eval_catch $funcname echo "$ECHO_APPEND" \
 	             'kern.geom.label.gptid.enable=\"0\"' \
 	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
 
@@ -1475,26 +1422,19 @@ zfs_create_boot()
 		'geom_eli_passphrase_prompt=\"YES\"' \
 		$BSDINSTALL_TMPBOOT/loader.conf.geli || return $FAILURE
 	for disk in $disks; do
-		if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
-			glabeldisktarget=$disk$targetpart
-			safeglabeldisktarget=$disk$targetpart
-		else
-			glabeldisktarget=$( glabel_of_diskpart $disk$targetpart )
-			safeglabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
-		fi
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
-			geli_%s_keyfile0_load "$safeglabeldisktarget YES" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
+			geli_%s_keyfile0_load "$disk$targetpart YES" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_type \
-			"$safeglabeldisktarget $glabeldisktarget:geli_keyfile0" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
+			"$disk$targetpart $disk$targetpart:geli_keyfile0" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_name \
-			"$safeglabeldisktarget \"$ZFSBOOT_GELI_KEY_FILE\"" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$safeglabeldisktarget ||
+			"$disk$targetpart \"$ZFSBOOT_GELI_KEY_FILE\"" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 	done
 

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -321,7 +321,7 @@ glabel_of_diskpart()
 {
 	local disk_and_part="$1"
 	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w )
+		local gptid=$( glabel status -s ${disk_and_part} | awk '{print $1}' )
 		if [ -n "${gptid}" ]; then
 			echo ${gptid}
 			return 0
@@ -339,7 +339,7 @@ safe_glabel_of_diskpart()
 {
 	local disk_and_part="$1"
 	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w | tr / _ )
+		local gptid=$( glabel status -s ${disk_and_part} | awk '{print $1}' | tr / _ )
 		if [ -n "${gptid}" ]; then
 			echo ${gptid}
 			return 0

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -41,11 +41,6 @@ f_include $BSDCFG_SHARE/variable.subr
 ############################################################ CONFIGURATION
 
 #
-# Use gptid or glabels
-#
-: ${ZFSBOOT_USE_GPTID=}
-
-#
 # Default name of the boot-pool
 #
 : ${ZFSBOOT_POOL_NAME:=zroot}
@@ -317,42 +312,6 @@ msg_yes="YES"
 msg_zfs_configuration="ZFS Configuration"
 
 ############################################################ FUNCTIONS
-
-# glabel_of_diskpart
-#
-# Translate $disk$part to its glabel(8) or gptid, otherwise $disk$part
-#
-glabel_of_diskpart()
-{
-	local disk_and_part="$1"
-	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w )
-		if [ -n "${gptid}" ]; then
-			echo ${gptid}
-			return 0
-		fi
-	fi
-	echo ${disk_and_part}
-	return 1
-}
-
-# safe_glabel_of_diskpart
-#
-# Translate $disk$part to its glabel(8) or gptid and translate / to _ , otherwise $disk$part
-#
-safe_glabel_of_diskpart()
-{
-	local disk_and_part="$1"
-	if [ -n "${disk_and_part}" ]; then
-		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w | tr / _ )
-		if [ -n "${gptid}" ]; then
-			echo ${gptid}
-			return 0
-		fi
-	fi
-	echo ${disk_and_part}
-	return 1
-}
 
 # dialog_menu_main
 #
@@ -899,15 +858,9 @@ zfs_create_diskpart()
 		#
 		# 2. Add small freebsd-boot partition labeled `gptboot#'
 		#
-		if [ "$ZFSBOOT_USE_GPTID" ]; then
-			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-					"$align_small" $index freebsd-boot 512k $disk ||
-					return $FAILURE
-		else
-			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_small" gptboot$index$uuid freebsd-boot 512k $disk ||
-					return $FAILURE
-		fi
+		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+				"$align_small" gptboot$index$uuid freebsd-boot 512k $disk ||
+				return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
 		             return $FAILURE
@@ -922,32 +875,19 @@ zfs_create_diskpart()
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
-			if [ "$ZFSBOOT_USE_GPTID" ]; then
-				f_eval_catch $funcname gpart \
-						"$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-						"$align_big" $index freebsd-zfs \
-						${bootsize}b $disk ||
-						return $FAILURE
-			else
-				f_eval_catch $funcname gpart \
-						"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-						"$align_big" boot$index$uuid freebsd-zfs \
-						${bootsize}b $disk ||
-						return $FAILURE
-			fi
+			f_eval_catch $funcname gpart \
+					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+					"$align_big" boot$index$uuid freebsd-zfs \
+					${bootsize}b $disk ||
+					return $FAILURE
 			# Pedantically nuke any old labels
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$bootpart
-			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
-			                /dev/$( glabel_of_diskpart $disk$bootpart )
 			if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 				# Pedantically detach targetpart for later
 				f_eval_catch -d $funcname geli \
 				                "$GELI_DETACH_F" \
 				                /dev/$disk$targetpart
-				f_eval_catch -d $funcname geli \
-				                "$GELI_DETACH_F" \
-				                /dev/$( glabel_of_diskpart $disk$targetpart )
 			fi
 		fi
 
@@ -955,54 +895,30 @@ zfs_create_diskpart()
 		# 3. Add freebsd-swap partition labeled `swap#'
 		#
 		if [ ${swapsize:-0} -gt 0 ]; then
-			if [ "$ZFSBOOT_USE_GPTID" ]; then
-				f_eval_catch $funcname gpart \
-						"$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-						"$align_big" $index freebsd-swap \
-						${swapsize}b $disk ||
-						return $FAILURE
-			else
-				f_eval_catch $funcname gpart \
-						"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-						"$align_big" swap$index$uuid freebsd-swap \
-						${swapsize}b $disk ||
-						return $FAILURE
-			fi
+			f_eval_catch $funcname gpart \
+					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+					"$align_big" swap$index$uuid freebsd-swap \
+					${swapsize}b $disk ||
+					return $FAILURE
 			# Pedantically nuke any old labels on the swap
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$swappart
-			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
-			                /dev/$( glabel_of_diskpart $disk$swappart )
 		fi
 
 		#
 		# 4. Add freebsd-zfs partition labeled `zfs#' for zroot
 		#
 		if [ "$ZFSBOOT_POOL_SIZE" ]; then
-			if [ "$ZFSBOOT_USE_GPTID" ]; then
-				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX_WITH_SIZE" \
-						"$align_big" $index freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
-						return $FAILURE
-			else
-				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-						"$align_big" zfs$index$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
-						return $FAILURE
-			fi
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+					"$align_big" zfs$index$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
+					return $FAILURE
 		else
-			if [ "$ZFSBOOT_USE_GPTID" ]; then
-				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_INDEX" \
-						"$align_big" $index freebsd-zfs $disk ||
-						return $FAILURE
-			else
-				f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
-						"$align_big" zfs$index$uuid freebsd-zfs $disk ||
-						return $FAILURE
-			fi
+			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
+					"$align_big" zfs$index$uuid freebsd-zfs $disk ||
+					return $FAILURE
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart
-		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
-		                /dev/$( glabel_of_diskpart $disk$targetpart )
 		;;
 
 	MBR) f_dprintf "$funcname: Creating MBR layout..."
@@ -1048,16 +964,11 @@ zfs_create_diskpart()
 		# Pedantically nuke any old labels
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$bootpart
-		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
-		                /dev/$( glabel_of_diskpart $disk$bootpart )
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 			# Pedantically detach targetpart for later
 			f_eval_catch -d $funcname geli \
 			                "$GELI_DETACH_F" \
 					/dev/$disk$targetpart
-			f_eval_catch -d $funcname geli \
-			                "$GELI_DETACH_F" \
-					/dev/$( glabel_of_diskpart $disk$targetpart )
 		fi
 
 		#
@@ -1085,8 +996,6 @@ zfs_create_diskpart()
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 		                /dev/$disk$targetpart # Pedantic
-		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
-		                /dev/$( glabel_of_diskpart $disk$targetpart ) # Pedantic
 		f_eval_catch $funcname dd "$DD_WITH_OPTIONS" \
 		             /boot/zfsboot /dev/${disk}s1 count=1 ||
 		             return $FAILURE
@@ -1113,14 +1022,14 @@ zfs_create_diskpart()
 		isswapmirror=1
 	elif [ "$ZFSBOOT_SWAP_ENCRYPTION" ]; then
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$( glabel_of_diskpart $disk${swappart} ).eli none swap sw 0 0 \
+		             /dev/$disk${swappart}.eli none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	elif [ ${swapsize:-0} -eq 0 ]; then
 		# If swap is 0 sized, don't add it to fstab
 	else
 		f_eval_catch $funcname printf "$PRINTF_FSTAB" \
-		             /dev/$( glabel_of_diskpart $disk$swappart ) none swap sw 0 0 \
+		             /dev/$disk$swappart none swap sw 0 0 \
 		             $BSDINSTALL_TMPETC/fstab ||
 		             return $FAILURE
 	fi
@@ -1233,9 +1142,9 @@ zfs_create_boot()
 		# Now $bootpart, $targetpart, and $swappart are set (suffix
 		# for $disk)
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
-			boot_vdevs="$boot_vdevs $( glabel_of_diskpart $disk$bootpart )"
+			boot_vdevs="$boot_vdevs $disk$bootpart"
 		fi
-		zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart )"
+		zroot_vdevs="$zroot_vdevs $disk$targetpart"
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 			zroot_vdevs="$zroot_vdevs.eli"
 		fi
@@ -1315,9 +1224,9 @@ zfs_create_boot()
 				2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_PASSWORD_INIT" \
-				"$bootpool/boot/$( safe_glabel_of_diskpart $disk$targetpart ).eli" \
+				"$bootpool/boot/$disk$targetpart.eli" \
 				AES-XTS "$bootpool/$zroot_key" \
-				$( glabel_of_diskpart $disk$targetpart )
+				$disk$targetpart
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1325,7 +1234,7 @@ zfs_create_boot()
 			fi
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_ATTACH" \
-				"$bootpool/$zroot_key" $( glabel_of_diskpart $disk$targetpart )
+				"$bootpool/$zroot_key" $disk$targetpart
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1345,7 +1254,7 @@ zfs_create_boot()
 	#
 	if [ "$ZFSBOOT_SWAP_MIRROR" ]; then
 		for disk in $disks; do
-			swap_devs="$swap_devs $( glabel_of_diskpart $disk$swappart )"
+			swap_devs="$swap_devs $disk$swappart"
 		done
 		f_eval_catch $funcname gmirror "$SWAP_GMIRROR_LABEL" \
 			"$swap_devs" || return $FAILURE
@@ -1516,17 +1425,17 @@ zfs_create_boot()
 		$BSDINSTALL_TMPBOOT/loader.conf.geli || return $FAILURE
 	for disk in $disks; do
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
-			geli_%s_keyfile0_load "$( safe_glabel_of_diskpart $disk$targetpart ) YES" \
+			geli_%s_keyfile0_load "$disk$targetpart YES" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_type \
-			"$( safe_glabel_of_diskpart $disk$targetpart ) $( glabel_of_diskpart $disk$targetpart ):geli_keyfile0" \
+			"$disk$targetpart $disk$targetpart:geli_keyfile0" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_name \
-			"$( safe_glabel_of_diskpart $disk$targetpart ) \"$ZFSBOOT_GELI_KEY_FILE\"" \
+			"$disk$targetpart \"$ZFSBOOT_GELI_KEY_FILE\"" \
 			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
 			return $FAILURE
 	done

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -857,8 +857,8 @@ zfs_create_diskpart()
 		# 2. Add small freebsd-boot partition labeled `boot#'
 		#
 		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-			     "$align_small" gptboot$index freebsd-boot 512k $disk ||
-			     return $FAILURE
+		             "$align_small" gptboot$index freebsd-boot 512k $disk ||
+		             return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
 		             return $FAILURE
@@ -874,10 +874,10 @@ zfs_create_diskpart()
 			bootpart=p2 swappart=p3 targetpart=p3
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
 			f_eval_catch $funcname gpart \
-				     "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-				     "$align_big" boot$index freebsd-zfs \
-				     ${bootsize}b $disk ||
-				     return $FAILURE
+			             "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+			             "$align_big" boot$index freebsd-zfs \
+			             ${bootsize}b $disk ||
+			             return $FAILURE
 			# Pedantically nuke any old labels
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$bootpart
@@ -894,10 +894,10 @@ zfs_create_diskpart()
 		#
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
-				     "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-				     "$align_big" swap$index freebsd-swap \
-				     ${swapsize}b $disk ||
-				     return $FAILURE
+			             "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
+			             "$align_big" swap$index freebsd-swap \
+			             ${swapsize}b $disk ||
+			             return $FAILURE
 			# Pedantically nuke any old labels on the swap
 			f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \
 			                /dev/$disk$swappart

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -895,7 +895,7 @@ zfs_create_diskpart()
 		# 2. Add small freebsd-boot partition labeled `gptboot#'
 		#
 		f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-				"$align_small" gptboot$index$uuid freebsd-boot 512k $disk ||
+				"$align_small" gptboot$uuid freebsd-boot 512k $disk ||
 				return $FAILURE
 		f_eval_catch $funcname gpart "$GPART_BOOTCODE_PART" \
 		             /boot/pmbr /boot/gptzfsboot 1 $disk ||
@@ -913,7 +913,7 @@ zfs_create_diskpart()
 			[ ${swapsize:-0} -gt 0 ] && targetpart=p4
 			f_eval_catch $funcname gpart \
 					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" boot$index$uuid freebsd-zfs \
+					"$align_big" boot$uuid freebsd-zfs \
 					${bootsize}b $disk ||
 					return $FAILURE
 			# Pedantically nuke any old labels
@@ -933,7 +933,7 @@ zfs_create_diskpart()
 		if [ ${swapsize:-0} -gt 0 ]; then
 			f_eval_catch $funcname gpart \
 					"$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" swap$index$uuid freebsd-swap \
+					"$align_big" swap$uuid freebsd-swap \
 					${swapsize}b $disk ||
 					return $FAILURE
 			# Pedantically nuke any old labels on the swap
@@ -946,11 +946,11 @@ zfs_create_diskpart()
 		#
 		if [ "$ZFSBOOT_POOL_SIZE" ]; then
 			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL_WITH_SIZE" \
-					"$align_big" zfs$index$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
+					"$align_big" zfs$uuid freebsd-zfs $ZFSBOOT_POOL_SIZE $disk ||
 					return $FAILURE
 		else
 			f_eval_catch $funcname gpart "$GPART_ADD_ALIGN_LABEL" \
-					"$align_big" zfs$index$uuid freebsd-zfs $disk ||
+					"$align_big" zfs$uuid freebsd-zfs $disk ||
 					return $FAILURE
 		fi
 		f_eval_catch -d $funcname zpool "$ZPOOL_LABELCLEAR_F" \

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -45,7 +45,7 @@ f_include $BSDCFG_SHARE/variable.subr
 : ${ZFSBOOT_POOL_NAME:=zroot}
 
 #
-# Default pool size
+# Default pool size is optional
 #
 : ${ZFSBOOT_POOL_SIZE=}
 

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -313,6 +313,42 @@ msg_zfs_configuration="ZFS Configuration"
 
 ############################################################ FUNCTIONS
 
+# glabel_of_diskpart
+#
+# Translate $disk$part to its glabel(8) or gptid, otherwise $disk$part
+#
+glabel_of_diskpart()
+{
+	local disk_and_part="$1"
+	if [ -n "${disk_and_part}" ]; then
+		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w )
+		if [ -n "${gptid}" ]; then
+			echo ${gptid}
+			return 0
+		fi
+	fi
+	echo ${disk_and_part}
+	return 1
+}
+
+# safe_glabel_of_diskpart
+#
+# Translate $disk$part to its glabel(8) or gptid and translate / to _ , otherwise $disk$part
+#
+safe_glabel_of_diskpart()
+{
+	local disk_and_part="$1"
+	if [ -n "${disk_and_part}" ]; then
+		local gptid=$( glabel status -s ${disk_and_part} | cut -f1 -w | tr / _ )
+		if [ -n "${gptid}" ]; then
+			echo ${gptid}
+			return 0
+		fi
+	fi
+	echo ${disk_and_part}
+	return 1
+}
+
 # dialog_menu_main
 #
 # Display the dialog(1)-based application main menu.
@@ -1055,6 +1091,7 @@ zfs_create_boot()
 	local isswapmirror
 	local bootpart targetpart swappart # Set by zfs_create_diskpart() below
 	local create_options
+	local glabeldisktarget
 
 	#
 	# Pedantic checks; should never be seen
@@ -1138,13 +1175,18 @@ zfs_create_boot()
 	fi
 	local n=0
 	for disk in $disks; do
+		if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
+			glabeldisktarget=$disk$targetpart
+		else
+			glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
+		fi
 		zfs_create_diskpart $disk $n || return $FAILURE
 		# Now $bootpart, $targetpart, and $swappart are set (suffix
 		# for $disk)
 		if [ "$ZFSBOOT_BOOT_POOL" ]; then
-			boot_vdevs="$boot_vdevs $disk$bootpart"
+			boot_vdevs="$boot_vdevs $( glabel_of_diskpart $disk$bootpart )"
 		fi
-		zroot_vdevs="$zroot_vdevs $disk$targetpart"
+		zroot_vdevs="$zroot_vdevs $( glabel_of_diskpart $disk$targetpart )"
 		if [ "$ZFSBOOT_GELI_ENCRYPTION" ]; then
 			zroot_vdevs="$zroot_vdevs.eli"
 		fi
@@ -1220,13 +1262,18 @@ zfs_create_boot()
 
 		# Initialize geli(8) on each of the target partitions
 		for disk in $disks; do
+			if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
+				glabeldisktarget=$disk$targetpart
+			else
+				glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
+			fi
 			f_dialog_info "$msg_geli_setup" \
 				2>&1 >&$DIALOG_TERMINAL_PASSTHRU_FD
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_PASSWORD_INIT" \
-				"$bootpool/boot/$disk$targetpart.eli" \
+				"$bootpool/boot/$glabeldisktarget.eli" \
 				AES-XTS "$bootpool/$zroot_key" \
-				$disk$targetpart
+				$glabeldisktarget
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1234,7 +1281,7 @@ zfs_create_boot()
 			fi
 			if ! echo "$pw_password" | f_eval_catch \
 				$funcname geli "$GELI_ATTACH" \
-				"$bootpool/$zroot_key" $disk$targetpart
+				"$bootpool/$zroot_key" $glabeldisktarget
 			then
 				f_interactive || f_die
 				unset pw_password # Sensitive info
@@ -1376,6 +1423,9 @@ zfs_create_boot()
 	             'kern.geom.label.disk_ident.enable=\"0\"' \
 	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
 	f_eval_catch $funcname echo "$ECHO_APPEND" \
+	             'kern.geom.label.gpt.enable=\"1\"' \
+	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
+	f_eval_catch $funcname echo "$ECHO_APPEND" \
 	             'kern.geom.label.gptid.enable=\"0\"' \
 	             $BSDINSTALL_TMPBOOT/loader.conf.zfs || return $FAILURE
 
@@ -1424,19 +1474,24 @@ zfs_create_boot()
 		'geom_eli_passphrase_prompt=\"YES\"' \
 		$BSDINSTALL_TMPBOOT/loader.conf.geli || return $FAILURE
 	for disk in $disks; do
+		if [ "$ZFSBOOT_PARTITION_SCHEME" = "MBR" ]; then
+			glabeldisktarget=$disk$targetpart
+		else
+			glabeldisktarget=$( safe_glabel_of_diskpart $disk$targetpart )
+		fi
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
-			geli_%s_keyfile0_load "$disk$targetpart YES" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
+			geli_%s_keyfile0_load "$glabeldisktarget YES" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_type \
-			"$disk$targetpart $disk$targetpart:geli_keyfile0" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
+			"$glabeldisktarget $glabeldisktarget:geli_keyfile0" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
 			return $FAILURE
 		f_eval_catch $funcname printf "$PRINTF_CONF" \
 			geli_%s_keyfile0_name \
-			"$disk$targetpart \"$ZFSBOOT_GELI_KEY_FILE\"" \
-			$BSDINSTALL_TMPBOOT/loader.conf.$disk$targetpart ||
+			"$glabeldisktarget \"$ZFSBOOT_GELI_KEY_FILE\"" \
+			$BSDINSTALL_TMPBOOT/loader.conf.$glabeldisktarget ||
 			return $FAILURE
 	done
 


### PR DESCRIPTION
- Introduce an optional variable `ZFSBOOT_POOL_SIZE` so users can use a smaller partition of their disk instead of "the rest of the disk".
